### PR TITLE
Fix duplicate ECS cluster resource

### DIFF
--- a/infra/network.tf
+++ b/infra/network.tf
@@ -41,6 +41,3 @@ resource "aws_route_table_association" "public_subnet_asso" {
  route_table_id = aws_route_table.second_rt.id
 }
 
-resource "aws_ecs_cluster" "ecs_cluster" {
-  name = "hado-cluster"
-}


### PR DESCRIPTION
## Summary
- remove redundant ECS cluster from Terraform network config

## Testing
- `node app.js`

------
https://chatgpt.com/codex/tasks/task_e_684b35913a90832984c06255201972e9